### PR TITLE
chore(docs): added tokio_stream::StreamExt

### DIFF
--- a/docs/usage/streams_sub.mdx
+++ b/docs/usage/streams_sub.mdx
@@ -82,6 +82,7 @@ for tx := range ch {
 
 ```rust
 use fiber::Client;
+use tokio_util::StreamExt;
 
 #[tokio::main]
 async fn main() {
@@ -207,6 +208,7 @@ Constructing filters with the Rust package is not very ergonomic yet. We're work
 
 ```rust
 use fiber::Client;
+use tokio_util::StreamExt;
 
 #[tokio::main]
 async fn main() {
@@ -313,6 +315,7 @@ func main() {
 
 ```rust
 use fiber::Client;
+use tokio_util::StreamExt;
 
 #[tokio::main]
 async fn main() {
@@ -408,6 +411,7 @@ func main() {
 
 ```rust
 use fiber::Client;
+use tokio_util::StreamExt;
 
 #[tokio::main]
 async fn main() {
@@ -503,6 +507,7 @@ func main() {
 
 ```rust
 use fiber::Client;
+use tokio_util::StreamExt;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Added missing `tokio_stream::StreamExt` directive to fiber-rs examples.

ref: https://github.com/chainbound/fiber-rs/pull/11